### PR TITLE
Use newer smlfut with values_into to avoid a copy.

### DIFF
--- a/fut/raytracer/FutRay.sml
+++ b/fut/raytracer/FutRay.sml
@@ -28,11 +28,11 @@ struct
       Ray.Opaque.prepared_scene.free (#prepared scene)
 
   fun render ctx {prepared,height,width} output : unit =
-      let val (data, start, len) = ArraySlice.base output
+      let val (data, start, len) = Int32ArraySlice.base output
           val arr = Ray.Entry.render_pixels ctx (height, width, start, len, prepared)
-          val arr_sml = Ray.Int32Array1.values arr
+          val () = Ray.Int32Array1.values_into arr output
           val () = Ray.Int32Array1.free arr
-      in Int32Array.appi (fn (i, x) => ArraySlice.update (output, i, x)) arr_sml
+      in ()
       end
 
 end

--- a/fut/raytracer/FutRay.sml
+++ b/fut/raytracer/FutRay.sml
@@ -30,9 +30,9 @@ struct
   fun render ctx {prepared,height,width} output : unit =
       let val (data, start, len) = ArraySlice.base output
           val arr = Ray.Entry.render_pixels ctx (height, width, start, len, prepared)
-          val arr_sml = Ray.Int32Array1.values arr
+          val () = Ray.Int32Array1.values_into arr output
           val () = Ray.Int32Array1.free arr
-      in Int32Array.appi (fn (i, x) => ArraySlice.update (output, i, x)) arr_sml
+      in ()
       end
 
 end

--- a/fut/raytracer/FutRay.sml
+++ b/fut/raytracer/FutRay.sml
@@ -28,11 +28,11 @@ struct
       Ray.Opaque.prepared_scene.free (#prepared scene)
 
   fun render ctx {prepared,height,width} output : unit =
-      let val (data, start, len) = Int32ArraySlice.base output
+      let val (data, start, len) = ArraySlice.base output
           val arr = Ray.Entry.render_pixels ctx (height, width, start, len, prepared)
-          val () = Ray.Int32Array1.values_into arr output
+          val arr_sml = Ray.Int32Array1.values arr
           val () = Ray.Int32Array1.free arr
-      in ()
+      in Int32Array.appi (fn (i, x) => ArraySlice.update (output, i, x)) arr_sml
       end
 
 end

--- a/fut/raytracer/Makefile
+++ b/fut/raytracer/Makefile
@@ -11,10 +11,10 @@ MLTONFLAGS = \
 MPL=/home/ec2-user/proj/mpl/hybrid-sched/build/bin/mpl
 
 main.mpl.bin: phony futray
-	$(MPL) $(MLTONFLAGS) -output main.mpl.bin main.mlb ../common/timer.c futray/ray.c
+	$(MPL) $(MLTONFLAGS) -output main.mpl.bin main.mlb ../common/timer.c futray/ray.c futray/ray.smlfut.c
 
 main.mpl: phony futray
-	$(MPL) $(MLTONFLAGS) -output main.mpl main.mlb ../common/timer.c futray/ray.c
+	$(MPL) $(MLTONFLAGS) -output main.mpl main.mlb ../common/timer.c futray/ray.c futray/ray.smlfut.c
 
 futray: phony
 	$(MAKE) -C futray

--- a/fut/raytracer/Ray.sml
+++ b/fut/raytracer/Ray.sml
@@ -308,6 +308,8 @@ struct
     end
 
   type pixel = Int32.int
+  structure PixelArray = Int32Array
+  structure PixelArraySlice = Int32ArraySlice
 
   fun colour_to_pixel {x = r, y = g, z = b} : pixel =
     let
@@ -331,7 +333,7 @@ struct
       (Word32.toInt r, Word32.toInt g, Word32.toInt b)
     end
 
-  type image = {pixels: pixel Array.array, height: int, width: int}
+  type image = {pixels: PixelArray.array, height: int, width: int}
 
   fun image2ppm out ({pixels, height, width}: image) =
     let
@@ -345,7 +347,7 @@ struct
         ( out
         , "P3\n" ^ Int.toString width ^ " " ^ Int.toString height ^ "\n"
           ^ "255\n"
-        ) before Array.app (onPixel o pixel_to_rgb) pixels
+        ) before PixelArray.app (onPixel o pixel_to_rgb) pixels
     end
 
   fun image2ppm6 out ({pixels, height, width}: image) =
@@ -357,7 +359,7 @@ struct
         ( out
         , "P6\n" ^ Int.toString width ^ " " ^ Int.toString height ^ "\n"
           ^ "255\n"
-        ) before Array.app (onPixel o pixel_to_rgb) pixels
+        ) before PixelArray.app (onPixel o pixel_to_rgb) pixels
     end
 
 
@@ -372,19 +374,19 @@ struct
 
   fun render_hybrid ctx fut_prepared_scene objs width height cam : image =
     let
-      val pixels: Int32.int array = ForkJoin.alloc (height * width)
+      val pixels = PixelArray.array (height * width, 0)
 
       fun writePixel l =
         let
           val i = l mod width
           val j = height - l div width
         in
-          Array.update (pixels, l, colour_to_pixel
+          PixelArray.update (pixels, l, colour_to_pixel
             (trace_ray objs width height cam j i))
         end
 
       fun gpuTask lo hi =
-        FutRay.render ctx fut_prepared_scene (ArraySlice.slice
+        FutRay.render ctx fut_prepared_scene (PixelArraySlice.slice
           (pixels, lo, SOME (hi - lo)))
 
       fun loop lo hi =
@@ -406,14 +408,14 @@ struct
 
   fun render_cpu objs width height cam : image =
     let
-      val pixels: Int32.int array = ForkJoin.alloc (height * width)
+      val pixels = PixelArray.array (height * width, 0)
 
       fun writePixel l =
         let
           val i = l mod width
           val j = height - l div width
         in
-          Array.update (pixels, l, colour_to_pixel
+          PixelArray.update (pixels, l, colour_to_pixel
             (trace_ray objs width height cam j i))
         end
     in
@@ -424,8 +426,8 @@ struct
 
   fun render_gpu ctx fut_prepared_scene width height : image =
     let
-      val pixels: Int32.int array = ForkJoin.alloc (height * width)
-      val doGpu = FutRay.render ctx fut_prepared_scene (ArraySlice.full pixels)
+      val pixels = PixelArray.array (height * width, 0)
+      val doGpu = FutRay.render ctx fut_prepared_scene (PixelArraySlice.full pixels)
       fun ensureOnGpu () =
         ForkJoin.choice {prefer_cpu = ensureOnGpu, prefer_gpu = fn () => doGpu}
     in

--- a/fut/raytracer/futray/.gitignore
+++ b/fut/raytracer/futray/.gitignore
@@ -3,3 +3,4 @@ ray.h
 ray.json
 ray.sig
 ray.sml
+ray.smlfut.c

--- a/fut/raytracer/futray/Makefile
+++ b/fut/raytracer/futray/Makefile
@@ -1,6 +1,6 @@
 default: phony
 	futhark cuda --library ray.fut
-	smlfut ray.json -o . --signature-name RAY --structure-name Ray
+	smlfut ray.json --output-dir . --signature-name RAY --structure-name Ray --poly-arrays
 
 clean: phony
 	rm -f ray.c ray.h ray.json


### PR DESCRIPTION
Unfortunately, this also required me to move from ForkJoin.alloc to Int32Array.array.  I think that is fine for the raytracer, but it could be a performance problem elsewhere, as it forces an early initialisation.

Does MLton/MPL have a way to convert between polymorphic and monomorphic array representations?  After all, they are identical at runtime, as I understand it.